### PR TITLE
免除对httpie的依赖，用curl替代

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,15 +109,7 @@ git pull origin
 
 **注**: 如果抽风了, 可以尝试使用 `git reset --hard` 等操作, 还原到最初的状态.
 
-1. 安装 脚本依赖 `httpie`
-
-以下是 `Ubuntu` 安装方法, 其它参考 https://httpie.org/doc#linux
-
-``` bash
-sudo apt install httpie
-```
-
-2. 执行更新, 自动下载最新 `Windows x64` 版开发者工具, 并且使用`wine`安装.  
+执行更新, 自动下载最新 `Windows x64` 版开发者工具, 并且使用`wine`安装.  
 
 ``` bash
 ./bin/update_package_nw.sh

--- a/bin/update_package_nw.sh
+++ b/bin/update_package_nw.sh
@@ -16,7 +16,7 @@ echo "当前wechat_v: $cur_wechat_v"
 wcwd_package_dir="$HOME/.wine/drive_c/users/$USERNAME/Application Data/Tencent/微信web开发者工具/package.nw"
 vendor_dir="$root_dir/package.nw/js/vendor"
 wcwd_download='https://servicewechat.com/wxa-dev-logic/download_redirect?type=x64&from=mpwiki'
-wechat_v=$(http --headers $wcwd_download | grep -oP --color=never '(?<=wechat_devtools_)[\d\.]+(?=_x64\.exe)')
+wechat_v=$(curl -sD - $wcwd_download | grep -oP --color=never '(?<=wechat_devtools_)[\d\.]+(?=_x64\.exe)')
 
 
 if [ -z "$wechat_v" ]; then


### PR DESCRIPTION
理由一：常规环境通常不带httpie，但是会带curl，后者更为通用
理由二：对于httpie，我有其它性能更好的替代品，因此我不想安装httpie