### PR TITLE
忽略 docker build 中不相关的文件

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!bin
+!package.nw


### PR DESCRIPTION
`docker build` 的时候应该忽略掉不相关的文件夹, 添加了 `.dockerignore` 能忽略掉将近 400M 的 `.git` 文件夹, 加快 build 速度