### PR TITLE
fix: $root_dir/bin/WeappVendor/ is not a directory

### DIFF
--- a/bin/replace_weapp_vendor.sh
+++ b/bin/replace_weapp_vendor.sh
@@ -49,6 +49,11 @@ fi
 
 if [ -d "$dev_tools_config_dir" ]; then
   echo "cp -rf $root_dir/bin/WeappVendor/* $dev_tools_config_dir/WeappVendor/"
+  
+  if [ ! -d "$root_dir/bin/WeappVendor" ]; then #in case directory doesn't exist
+    mkdir $root_dir/bin/WeappVendor
+  fi
+  
   cp -rf $root_dir/bin/WeappVendor/* "$dev_tools_config_dir/WeappVendor/"
   mkdir -p "$dev_tools_config_dir/WeappVendor/s"
   echo cp -rf $vendor_dir/wcc.exe $vendor_dir/wcsc.exe "$dev_tools_config_dir/WeappVendor/s/"


### PR DESCRIPTION
It may fix issue #213 
I don't know what `cp -rf $root_dir/bin/WeappVendor/* "$dev_tools_config_dir/WeappVendor/"` did.
But creating THE DIRECTORY seems to solve the problem.